### PR TITLE
#27 feat 로그인 api 연동

### DIFF
--- a/data/src/main/java/com/capston/data/di/ApiModule.kt
+++ b/data/src/main/java/com/capston/data/di/ApiModule.kt
@@ -3,6 +3,7 @@ package com.capston.data.di
 import com.capston.data.repository.remote.api.DailyScheduleApi
 import com.capston.data.repository.remote.api.ErrorApi
 import com.capston.data.repository.remote.api.HomeApi
+import com.capston.data.repository.remote.api.LoginApi
 import com.capston.data.repository.remote.api.PlanApi
 import dagger.Module
 import dagger.Provides
@@ -14,11 +15,11 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 object ApiModule {
-//    @Provides
-//    @Singleton
-//    fun provideLogInServer(
-//        @MainRetrofit retrofit: Retrofit
-//    ): LoginApi = retrofit.create(LoginApi::class.java)
+    @Provides
+    @Singleton
+    fun provideLogInServer(
+        @MainRetrofit retrofit: Retrofit
+    ): LoginApi = retrofit.create(LoginApi::class.java)
 
     @Provides
     @Singleton

--- a/data/src/main/java/com/capston/data/di/RepositoryModule.kt
+++ b/data/src/main/java/com/capston/data/di/RepositoryModule.kt
@@ -3,22 +3,27 @@ package com.capston.data.di
 import com.capston.data.repository.remote.api.DailyScheduleApi
 import com.capston.data.repository.remote.api.ErrorApi
 import com.capston.data.repository.remote.api.HomeApi
+import com.capston.data.repository.remote.api.LoginApi
 import com.capston.data.repository.remote.api.PlanApi
 import com.capston.data.repository.remote.datasourcelmpl.DailyScheduleDataSourceImpl
 import com.capston.data.repository.remote.datasourcelmpl.ErrorDataSourceImpl
 import com.capston.data.repository.remote.datasourcelmpl.HomeDataSourceImpl
+import com.capston.data.repository.remote.datasourcelmpl.LoginDataSourceImpl
 import com.capston.data.repository.remote.datasourcelmpl.PlanDataSourceImpl
 import com.capston.data.repository.remote.repositoryImpl.DailyScheduleRepositoryImpl
 import com.capston.data.repository.remote.repositoryImpl.ErrorRepositoryImpl
 import com.capston.data.repository.remote.repositoryImpl.HomeRepositoryImpl
+import com.capston.data.repository.remote.repositoryImpl.LoginRepositoryImpl
 import com.capston.data.repository.remote.repositoryImpl.PlanRepositoryImpl
 import com.capston.domain.datasource.DailyScheduleDataSource
 import com.capston.domain.datasource.ErrorDataSource
 import com.capston.domain.datasource.HomeDataSource
+import com.capston.domain.datasource.LoginDataSource
 import com.capston.domain.datasource.PlanDataSource
 import com.capston.domain.repository.DailyScheduleRepository
 import com.capston.domain.repository.ErrorRepository
 import com.capston.domain.repository.HomeRepository
+import com.capston.domain.repository.LoginRepository
 import com.capston.domain.repository.PlanRepository
 import dagger.Module
 import dagger.Provides
@@ -29,6 +34,19 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 object RepositoryModule {
+    // 로그인
+    @Provides
+    @Singleton
+    fun provideLoginDataSource(
+        loginApi: LoginApi
+    ): LoginDataSource {
+        return LoginDataSourceImpl(loginApi)
+    }
+
+    @Singleton
+    @Provides
+    fun provideLoginRepository(loginDataSource: LoginDataSource): LoginRepository =
+        LoginRepositoryImpl(loginDataSource)
 
     // 홈
     @Provides

--- a/data/src/main/java/com/capston/data/repository/remote/api/LoginApi.kt
+++ b/data/src/main/java/com/capston/data/repository/remote/api/LoginApi.kt
@@ -1,7 +1,7 @@
 package com.capston.data.repository.remote.api
 
 import com.capston.domain.request.LoginDto
-import com.capston.domain.response.Result
+import com.capston.domain.response.BaseResult
 import retrofit2.http.Body
 import retrofit2.http.POST
 
@@ -10,5 +10,5 @@ interface LoginApi {
     @POST("/api/users/login")
     suspend fun postLoginInfo(
         @Body loginDto: LoginDto
-    ): Result
+    ): BaseResult
 }

--- a/data/src/main/java/com/capston/data/repository/remote/api/LoginApi.kt
+++ b/data/src/main/java/com/capston/data/repository/remote/api/LoginApi.kt
@@ -1,0 +1,14 @@
+package com.capston.data.repository.remote.api
+
+import com.capston.domain.request.LoginDto
+import com.capston.domain.response.Result
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+interface LoginApi {
+    // 강의 별명 수정
+    @POST("/api/users/login")
+    suspend fun postLoginInfo(
+        @Body loginDto: LoginDto
+    ): Result
+}

--- a/data/src/main/java/com/capston/data/repository/remote/datasourcelmpl/DailyScheduleDataSourceImpl.kt
+++ b/data/src/main/java/com/capston/data/repository/remote/datasourcelmpl/DailyScheduleDataSourceImpl.kt
@@ -7,7 +7,7 @@ import com.capston.data.repository.remote.api.DailyScheduleApi
 import com.capston.domain.base.BaseLoadingState
 import com.capston.domain.datasource.DailyScheduleDataSource
 import com.capston.domain.response.BaseResponse
-import com.capston.domain.response.Result
+import com.capston.domain.response.BaseResult
 import com.capston.domain.response.daily_schedule.DailyScheduleResponse
 import com.capston.domain.response.enum_class.Day
 import kotlinx.coroutines.flow.Flow
@@ -35,8 +35,8 @@ class DailyScheduleDataSourceImpl @Inject constructor(
         val errorMessage = e.message ?: "알 수 없는 오류 발생"
         Log.e("DailyScheduleDataSourceImpl", "에러: $errorMessage")
 
-        val errorResponse = Result(code = 5000, message = errorMessage)
-        val response = BaseResponse(result = errorResponse, payload = null, status = BaseLoadingState.ERROR)
+        val errorResponse = BaseResult(code = 5000, message = errorMessage)
+        val response = BaseResponse(baseResult = errorResponse, payload = null, status = BaseLoadingState.ERROR)
 
         Log.e("DailyScheduleDataSourceImpl", response.toString())
     }

--- a/data/src/main/java/com/capston/data/repository/remote/datasourcelmpl/HomeDataSourceImpl.kt
+++ b/data/src/main/java/com/capston/data/repository/remote/datasourcelmpl/HomeDataSourceImpl.kt
@@ -4,11 +4,10 @@ import android.util.Log
 import com.capston.domain.base.BaseLoadingState
 import com.capston.data.repository.remote.api.HomeApi
 import com.capston.domain.datasource.HomeDataSource
-import com.capston.domain.request.PatchPlanDto
 import com.capston.domain.response.BaseResponse
 import com.capston.domain.response.CheckResponse
 import com.capston.domain.response.home.DistinctHomeIdResponse
-import com.capston.domain.response.Result
+import com.capston.domain.response.BaseResult
 import com.capston.domain.response.home.TodayScheduleResponse
 import com.capston.domain.response.home.UserProgressResponse
 import kotlinx.coroutines.flow.Flow
@@ -43,11 +42,11 @@ class HomeDataSourceImpl @Inject constructor(
 
         // JSON 파싱 함수 호출
         val parsedMessage = parseErrorMessage(errorMessage)
-        val errorResponse = Result(code = 5000, message = parsedMessage)
+        val errorResponse = BaseResult(code = 5000, message = parsedMessage)
 
         // BaseResponse로 감싸서 오류 상태를 emit
         val response = BaseResponse<DistinctHomeIdResponse>(
-            result = errorResponse,
+            baseResult = errorResponse,
             payload = null,
             status = BaseLoadingState.ERROR
         )
@@ -56,14 +55,14 @@ class HomeDataSourceImpl @Inject constructor(
 
         if (e is HttpException && e.code() == 404) {
             val errorResponse = BaseResponse<DistinctHomeIdResponse>(
-                result = Result(
+                baseResult = BaseResult(
                     code = 3000,
                     message = "홈 정보가 존재하지 않습니다."
                 ),
                 payload = null,
                 status = BaseLoadingState.ERROR // 상태를 ERROR로 설정
             )
-            Log.e("getDistinctHome", "HTTP 404: ${errorResponse.result.message}")
+            Log.e("getDistinctHome", "HTTP 404: ${errorResponse.baseResult.message}")
 //            emit(errorResponse) // 404 응답을 Flow로 emit
         } else {
             Log.e("getDistinctHome", "예외 발생: ${e.message}")

--- a/data/src/main/java/com/capston/data/repository/remote/datasourcelmpl/LoginDataSourceImpl.kt
+++ b/data/src/main/java/com/capston/data/repository/remote/datasourcelmpl/LoginDataSourceImpl.kt
@@ -1,0 +1,15 @@
+package com.capston.data.repository.remote.datasourcelmpl
+
+import com.capston.data.repository.remote.api.LoginApi
+import com.capston.domain.datasource.LoginDataSource
+import com.capston.domain.request.LoginDto
+import com.capston.domain.response.Result
+import javax.inject.Inject
+
+class LoginDataSourceImpl @Inject constructor(
+    private val loginApi: LoginApi
+): LoginDataSource {
+    override suspend fun postLoginInfo(loginDto: LoginDto): Result {
+        return loginApi.postLoginInfo(loginDto)
+    }
+}

--- a/data/src/main/java/com/capston/data/repository/remote/datasourcelmpl/LoginDataSourceImpl.kt
+++ b/data/src/main/java/com/capston/data/repository/remote/datasourcelmpl/LoginDataSourceImpl.kt
@@ -3,13 +3,13 @@ package com.capston.data.repository.remote.datasourcelmpl
 import com.capston.data.repository.remote.api.LoginApi
 import com.capston.domain.datasource.LoginDataSource
 import com.capston.domain.request.LoginDto
-import com.capston.domain.response.Result
+import com.capston.domain.response.BaseResult
 import javax.inject.Inject
 
 class LoginDataSourceImpl @Inject constructor(
     private val loginApi: LoginApi
 ): LoginDataSource {
-    override suspend fun postLoginInfo(loginDto: LoginDto): Result {
+    override suspend fun postLoginInfo(loginDto: LoginDto): BaseResult {
         return loginApi.postLoginInfo(loginDto)
     }
 }

--- a/data/src/main/java/com/capston/data/repository/remote/repositoryImpl/LoginRepositoryImpl.kt
+++ b/data/src/main/java/com/capston/data/repository/remote/repositoryImpl/LoginRepositoryImpl.kt
@@ -3,11 +3,11 @@ package com.capston.data.repository.remote.repositoryImpl
 import com.capston.domain.datasource.LoginDataSource
 import com.capston.domain.repository.LoginRepository
 import com.capston.domain.request.LoginDto
-import com.capston.domain.response.Result
+import com.capston.domain.response.BaseResult
 import javax.inject.Inject
 
 class LoginRepositoryImpl @Inject constructor(
     private val loginDataSource: LoginDataSource
 ): LoginRepository {
-    override suspend fun postLoginInfo(loginDto: LoginDto): Result = loginDataSource.postLoginInfo(loginDto)
+    override suspend fun postLoginInfo(loginDto: LoginDto): BaseResult = loginDataSource.postLoginInfo(loginDto)
 }

--- a/data/src/main/java/com/capston/data/repository/remote/repositoryImpl/LoginRepositoryImpl.kt
+++ b/data/src/main/java/com/capston/data/repository/remote/repositoryImpl/LoginRepositoryImpl.kt
@@ -1,0 +1,13 @@
+package com.capston.data.repository.remote.repositoryImpl
+
+import com.capston.domain.datasource.LoginDataSource
+import com.capston.domain.repository.LoginRepository
+import com.capston.domain.request.LoginDto
+import com.capston.domain.response.Result
+import javax.inject.Inject
+
+class LoginRepositoryImpl @Inject constructor(
+    private val loginDataSource: LoginDataSource
+): LoginRepository {
+    override suspend fun postLoginInfo(loginDto: LoginDto): Result = loginDataSource.postLoginInfo(loginDto)
+}

--- a/domain/src/main/java/com/capston/domain/datasource/LoginDataSource.kt
+++ b/domain/src/main/java/com/capston/domain/datasource/LoginDataSource.kt
@@ -1,0 +1,9 @@
+package com.capston.domain.datasource
+
+import com.capston.domain.request.LoginDto
+import com.capston.domain.response.Result
+
+interface LoginDataSource {
+    // 회원가입 후 사용자 정보 전송
+    suspend fun postLoginInfo(loginDto: LoginDto): Result
+}

--- a/domain/src/main/java/com/capston/domain/datasource/LoginDataSource.kt
+++ b/domain/src/main/java/com/capston/domain/datasource/LoginDataSource.kt
@@ -1,9 +1,9 @@
 package com.capston.domain.datasource
 
 import com.capston.domain.request.LoginDto
-import com.capston.domain.response.Result
+import com.capston.domain.response.BaseResult
 
 interface LoginDataSource {
     // 회원가입 후 사용자 정보 전송
-    suspend fun postLoginInfo(loginDto: LoginDto): Result
+    suspend fun postLoginInfo(loginDto: LoginDto): BaseResult
 }

--- a/domain/src/main/java/com/capston/domain/repository/LoginRepository.kt
+++ b/domain/src/main/java/com/capston/domain/repository/LoginRepository.kt
@@ -1,9 +1,9 @@
 package com.capston.domain.repository
 
 import com.capston.domain.request.LoginDto
-import com.capston.domain.response.Result
+import com.capston.domain.response.BaseResult
 
 interface LoginRepository {
     // 회원가입 후 사용자 정보 전송
-    suspend fun postLoginInfo(loginDto: LoginDto): Result
+    suspend fun postLoginInfo(loginDto: LoginDto): BaseResult
 }

--- a/domain/src/main/java/com/capston/domain/repository/LoginRepository.kt
+++ b/domain/src/main/java/com/capston/domain/repository/LoginRepository.kt
@@ -1,0 +1,9 @@
+package com.capston.domain.repository
+
+import com.capston.domain.request.LoginDto
+import com.capston.domain.response.Result
+
+interface LoginRepository {
+    // 회원가입 후 사용자 정보 전송
+    suspend fun postLoginInfo(loginDto: LoginDto): Result
+}

--- a/domain/src/main/java/com/capston/domain/request/LoginDto.kt
+++ b/domain/src/main/java/com/capston/domain/request/LoginDto.kt
@@ -1,0 +1,7 @@
+package com.capston.domain.request
+
+data class LoginDto (
+    val email: String = "",
+    val name: String = "",
+    val fcmToken: String = ""
+)

--- a/domain/src/main/java/com/capston/domain/request/LoginDto.kt
+++ b/domain/src/main/java/com/capston/domain/request/LoginDto.kt
@@ -1,7 +1,7 @@
 package com.capston.domain.request
 
 data class LoginDto (
-    val email: String = "",
-    val name: String = "",
-    val fcmToken: String = ""
+    val email: String? = "",
+    val name: String? = "",
+    val fcmToken: String? = ""
 )

--- a/domain/src/main/java/com/capston/domain/response/BaseResponse.kt
+++ b/domain/src/main/java/com/capston/domain/response/BaseResponse.kt
@@ -3,13 +3,13 @@ package com.capston.domain.response
 import com.capston.domain.base.BaseLoadingState
 
 data class BaseResponse<T>(
-    var result: Result = Result(),
+    var baseResult: BaseResult = BaseResult(),
     var payload: T? = null,
     var status: BaseLoadingState = BaseLoadingState.IDLE
 )
 
 // Result 클래스
-data class Result(
+data class BaseResult(
     var code: Int = 0,
     var message: String = ""
 )

--- a/domain/src/main/java/com/capston/domain/usecase/login/PostLoginInfoUseCase.kt
+++ b/domain/src/main/java/com/capston/domain/usecase/login/PostLoginInfoUseCase.kt
@@ -2,7 +2,7 @@ package com.capston.domain.usecase.login
 
 import com.capston.domain.repository.LoginRepository
 import com.capston.domain.request.LoginDto
-import com.capston.domain.response.Result
+import com.capston.domain.response.BaseResult
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
@@ -10,7 +10,7 @@ import javax.inject.Inject
 class PostLoginInfoUseCase @Inject constructor(
     private val repository: LoginRepository
 ) {
-    operator fun invoke(loginDto: LoginDto): Flow<Result> = flow {
+    operator fun invoke(loginDto: LoginDto): Flow<BaseResult> = flow {
         val response = repository.postLoginInfo(loginDto)
         emit(response)  // JSON 변환 없이 문자열 그대로 emit
     }

--- a/domain/src/main/java/com/capston/domain/usecase/login/PostLoginInfoUseCase.kt
+++ b/domain/src/main/java/com/capston/domain/usecase/login/PostLoginInfoUseCase.kt
@@ -1,0 +1,19 @@
+package com.capston.domain.usecase.login
+
+import com.capston.domain.repository.LoginRepository
+import com.capston.domain.request.LoginDto
+import com.capston.domain.response.Result
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import javax.inject.Inject
+
+class PostLoginInfoUseCase @Inject constructor(
+    private val repository: LoginRepository
+) {
+    operator fun invoke(loginDto: LoginDto): Flow<Result> = flow {
+        val response = repository.postLoginInfo(loginDto)
+        emit(response)  // JSON 변환 없이 문자열 그대로 emit
+    }
+}
+
+//이거하고 뷰모델만들기

--- a/presentation/src/main/java/com/capston/presentation/ui/login/LoginActivity.kt
+++ b/presentation/src/main/java/com/capston/presentation/ui/login/LoginActivity.kt
@@ -7,6 +7,7 @@ import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.viewModels
 import androidx.credentials.ClearCredentialStateRequest
 import androidx.credentials.Credential
 import androidx.credentials.CredentialManager
@@ -14,9 +15,11 @@ import androidx.credentials.GetCredentialRequest
 import androidx.credentials.exceptions.ClearCredentialException
 import androidx.credentials.exceptions.GetCredentialException
 import androidx.lifecycle.lifecycleScope
+import com.capston.domain.request.LoginDto
 import com.capston.presentation.R
 import com.capston.presentation.theme.CapstonTheme
 import com.capston.presentation.ui.MainActivity
+import com.capston.presentation.viewmodel.LoginViewModel
 import com.google.android.libraries.identity.googleid.GetGoogleIdOption
 import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
 import com.google.firebase.auth.FirebaseAuth
@@ -29,6 +32,8 @@ import kotlinx.coroutines.launch
 
 class LoginActivity : ComponentActivity() {
     private lateinit var auth: FirebaseAuth
+
+    val loginViewModel: LoginViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -71,7 +76,7 @@ class LoginActivity : ComponentActivity() {
             .setServerClientId(getString(R.string.google_client_id))
             // true: Only show accounts previously used to sign in.
             .setFilterByAuthorizedAccounts(false)
-            .setAutoSelectEnabled(true)
+            .setAutoSelectEnabled(false)
             .build()
 
         // 2) CredentialRequest 생성
@@ -113,6 +118,13 @@ class LoginActivity : ComponentActivity() {
                 if (task.isSuccessful) {
                     // Sign in success, update UI with the signed-in user's information
                     Log.d("LoginActivity", "signInWithCredential:success")
+                    // 백엔드에 회원가입 정보 전달
+                    loginViewModel.postLogin(
+                        LoginDto(
+                            auth.currentUser?.email,
+                            auth.currentUser?.displayName,
+                            "")
+                    )
                     // 로그인 성공 후 MainActivity로 이동
                     startActivity(Intent(this, MainActivity::class.java))
                     finish()

--- a/presentation/src/main/java/com/capston/presentation/viewmodel/LoginViewModel.kt
+++ b/presentation/src/main/java/com/capston/presentation/viewmodel/LoginViewModel.kt
@@ -1,0 +1,39 @@
+package com.capston.presentation.viewmodel
+
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.capston.domain.request.LoginDto
+import com.capston.domain.usecase.login.PostLoginInfoUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class LoginViewModel @Inject constructor(
+    private val postLoginInfoUseCase: PostLoginInfoUseCase
+): ViewModel() {
+    // 로그인 성공 여부를 나타내는 상태 변수(예: 이벤트 또는 플래그)
+    private val _basicResult = MutableStateFlow(Result)
+    private val _loginSuccess = MutableStateFlow(false)
+    val loginSuccess: StateFlow<Boolean> = _loginSuccess.asStateFlow()
+
+    fun postLogin(loginDto: LoginDto) {
+        viewModelScope.launch {
+            postLoginInfoUseCase(loginDto)
+                .catch { e ->
+                    Log.e("LoginViewModel", "postLogin error: ${e.message}")
+                    // 실패 처리를 위한 추가 로직 추가 가능
+                }
+                .collect {
+                    // 응답 데이터가 없다면 단순히 성공 여부를 업데이트
+                    _loginSuccess.value = true
+                    Log.d("LoginViewModel", "로그인 성공")
+                }
+        }
+    }
+}

--- a/presentation/src/main/java/com/capston/presentation/viewmodel/LoginViewModel.kt
+++ b/presentation/src/main/java/com/capston/presentation/viewmodel/LoginViewModel.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.capston.domain.request.LoginDto
+import com.capston.domain.response.BaseResult
 import com.capston.domain.usecase.login.PostLoginInfoUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -18,7 +19,7 @@ class LoginViewModel @Inject constructor(
     private val postLoginInfoUseCase: PostLoginInfoUseCase
 ): ViewModel() {
     // 로그인 성공 여부를 나타내는 상태 변수(예: 이벤트 또는 플래그)
-    private val _basicResult = MutableStateFlow(Result)
+    private val _basicResult = MutableStateFlow(BaseResult)
     private val _loginSuccess = MutableStateFlow(false)
     val loginSuccess: StateFlow<Boolean> = _loginSuccess.asStateFlow()
 


### PR DESCRIPTION
## #️⃣연관된 이슈

메인 이슈: #27, 참고 이슈: #7

## 📝작업 내용

1. 여러 파일에 걸쳐 API 사용을 위한 클래스 생성
2. POST 요청으로 가입자 이름과 이메일 전달
3. Result 클래스가 다른 클래스와 이름이 중복되어 BaseResult로 변경