### PR TITLE
#38 feat: 로그인 api로부터 액세스 토큰 응답

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -153,7 +153,4 @@ dependencies {
     implementation(libs.androidx.credentials.play.services.auth)
     implementation(libs.identity.googleid)
     implementation(libs.gms.play.services.auth)
-
-    implementation(libs.androidx.security.crypto.ktx)
-
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -154,5 +154,6 @@ dependencies {
     implementation(libs.identity.googleid)
     implementation(libs.gms.play.services.auth)
 
+    implementation(libs.androidx.security.crypto.ktx)
 
 }

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -56,7 +56,6 @@ dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)
     implementation(libs.material)
-    implementation(libs.androidx.security.crypto.ktx)
     implementation(libs.androidx.datastore.preferences)
     implementation(libs.androidx.datastore.core.android)
     testImplementation(libs.junit)
@@ -81,12 +80,5 @@ dependencies {
     implementation(libs.gson)
 
     // coroutines
-    //
     implementation(libs.kotlinx.coroutines.android)
-
-    // EncryptedSharedPreferences
-    implementation(libs.androidx.security.crypto)
-
-    implementation(libs.androidx.security.crypto.ktx)
-
 }

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -79,4 +79,8 @@ dependencies {
 
     // coroutines
     implementation(libs.kotlinx.coroutines.android)
+
+    // EncryptedSharedPreferences
+    implementation(libs.androidx.security.crypto)
+
 }

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -56,6 +56,9 @@ dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)
     implementation(libs.material)
+    implementation(libs.androidx.security.crypto.ktx)
+    implementation(libs.androidx.datastore.preferences)
+    implementation(libs.androidx.datastore.core.android)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
@@ -78,9 +81,12 @@ dependencies {
     implementation(libs.gson)
 
     // coroutines
+    //
     implementation(libs.kotlinx.coroutines.android)
 
     // EncryptedSharedPreferences
     implementation(libs.androidx.security.crypto)
+
+    implementation(libs.androidx.security.crypto.ktx)
 
 }

--- a/data/src/main/java/com/capston/data/di/StorageModule.kt
+++ b/data/src/main/java/com/capston/data/di/StorageModule.kt
@@ -1,0 +1,30 @@
+// data/src/main/java/com/capston/data/di/StorageModule.kt
+package com.capston.data.di
+
+import android.content.Context
+import com.capston.data.local.storage.TokenDataStore
+import com.capston.data.repository.TokenRepositoryImpl
+import com.capston.domain.repository.TokenRepository
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object StorageModule {
+
+    @Provides
+    @Singleton
+    fun provideTokenDataStore(@ApplicationContext context: Context): TokenDataStore {
+        return TokenDataStore(context)
+    }
+
+    @Provides
+    @Singleton
+    fun provideTokenRepository(tokenDataStore: TokenDataStore): TokenRepository {
+        return TokenRepositoryImpl(tokenDataStore)
+    }
+}

--- a/data/src/main/java/com/capston/data/local/storage/TokenDataStore.kt
+++ b/data/src/main/java/com/capston/data/local/storage/TokenDataStore.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.flow.map
 // Context 확장 속성으로 dataStore 인스턴스 정의
 private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "auth_tokens")
 
-class TokenManager(private val context: Context) {
+class TokenDataStore(private val context: Context) {
 
     companion object {
         private val ACCESS_TOKEN_KEY = stringPreferencesKey("access_token")

--- a/data/src/main/java/com/capston/data/local/storage/TokenManager.kt
+++ b/data/src/main/java/com/capston/data/local/storage/TokenManager.kt
@@ -1,0 +1,63 @@
+package com.capston.data.local.storage
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+// Context 확장 속성으로 dataStore 인스턴스 정의
+private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "auth_tokens")
+
+class TokenManager(private val context: Context) {
+
+    companion object {
+        private val ACCESS_TOKEN_KEY = stringPreferencesKey("access_token")
+        private val REFRESH_TOKEN_KEY = stringPreferencesKey("refresh_token")
+    }
+
+    // 액세스 토큰 저장
+    suspend fun saveAccessToken(token: String) {
+        context.dataStore.edit { preferences ->
+            preferences[ACCESS_TOKEN_KEY] = token
+        }
+    }
+
+    // 리프레시 토큰 저장
+    suspend fun saveRefreshToken(token: String) {
+        context.dataStore.edit { preferences ->
+            preferences[REFRESH_TOKEN_KEY] = token
+        }
+    }
+
+    // 두 토큰 함께 저장
+    suspend fun saveTokens(accessToken: String, refreshToken: String) {
+        context.dataStore.edit { preferences ->
+            preferences[ACCESS_TOKEN_KEY] = accessToken
+            preferences[REFRESH_TOKEN_KEY] = refreshToken
+        }
+    }
+
+    // 액세스 토큰 가져오기
+    val accessToken: Flow<String?> = context.dataStore.data
+        .map { preferences ->
+            preferences[ACCESS_TOKEN_KEY]
+        }
+
+    // 리프레시 토큰 가져오기
+    val refreshToken: Flow<String?> = context.dataStore.data
+        .map { preferences ->
+            preferences[REFRESH_TOKEN_KEY]
+        }
+
+    // 토큰 삭제
+    suspend fun clearTokens() {
+        context.dataStore.edit { preferences ->
+            preferences.remove(ACCESS_TOKEN_KEY)
+            preferences.remove(REFRESH_TOKEN_KEY)
+        }
+    }
+}

--- a/data/src/main/java/com/capston/data/repository/remote/api/LoginApi.kt
+++ b/data/src/main/java/com/capston/data/repository/remote/api/LoginApi.kt
@@ -2,6 +2,7 @@ package com.capston.data.repository.remote.api
 
 import com.capston.domain.request.LoginDto
 import com.capston.domain.response.BaseResult
+import com.capston.domain.response.LoginResponse
 import retrofit2.http.Body
 import retrofit2.http.POST
 
@@ -10,5 +11,5 @@ interface LoginApi {
     @POST("/api/users/login")
     suspend fun postLoginInfo(
         @Body loginDto: LoginDto
-    ): BaseResult
+    ): LoginResponse
 }

--- a/data/src/main/java/com/capston/data/repository/remote/datasourcelmpl/LoginDataSourceImpl.kt
+++ b/data/src/main/java/com/capston/data/repository/remote/datasourcelmpl/LoginDataSourceImpl.kt
@@ -1,15 +1,20 @@
 package com.capston.data.repository.remote.datasourcelmpl
 
+import android.util.Log
 import com.capston.data.repository.remote.api.LoginApi
 import com.capston.domain.datasource.LoginDataSource
 import com.capston.domain.request.LoginDto
 import com.capston.domain.response.BaseResult
+import com.capston.domain.response.LoginResponse
 import javax.inject.Inject
 
 class LoginDataSourceImpl @Inject constructor(
     private val loginApi: LoginApi
 ): LoginDataSource {
-    override suspend fun postLoginInfo(loginDto: LoginDto): BaseResult {
+    override suspend fun postLoginInfo(loginDto: LoginDto): LoginResponse {
+        val response = loginApi.postLoginInfo(loginDto)
+        // 액세스 토큰 로그 출력
+        Log.d("LoginDataSourceImpl", "Token: ${response.token}")
         return loginApi.postLoginInfo(loginDto)
     }
 }

--- a/data/src/main/java/com/capston/data/repository/remote/datasourcelmpl/LoginDataSourceImpl.kt
+++ b/data/src/main/java/com/capston/data/repository/remote/datasourcelmpl/LoginDataSourceImpl.kt
@@ -13,7 +13,7 @@ class LoginDataSourceImpl @Inject constructor(
     override suspend fun postLoginInfo(loginDto: LoginDto): LoginResponse {
         val response = loginApi.postLoginInfo(loginDto)
         // 액세스 토큰 로그 출력
-        Log.d("LoginDataSourceImpl", "Token: ${response.accessToken}")
+        Log.d("LoginDataSourceImpl", "Token: ${response.token}")
         return loginApi.postLoginInfo(loginDto)
     }
 }

--- a/data/src/main/java/com/capston/data/repository/remote/datasourcelmpl/LoginDataSourceImpl.kt
+++ b/data/src/main/java/com/capston/data/repository/remote/datasourcelmpl/LoginDataSourceImpl.kt
@@ -4,7 +4,6 @@ import android.util.Log
 import com.capston.data.repository.remote.api.LoginApi
 import com.capston.domain.datasource.LoginDataSource
 import com.capston.domain.request.LoginDto
-import com.capston.domain.response.BaseResult
 import com.capston.domain.response.LoginResponse
 import javax.inject.Inject
 
@@ -14,7 +13,7 @@ class LoginDataSourceImpl @Inject constructor(
     override suspend fun postLoginInfo(loginDto: LoginDto): LoginResponse {
         val response = loginApi.postLoginInfo(loginDto)
         // 액세스 토큰 로그 출력
-        Log.d("LoginDataSourceImpl", "Token: ${response.token}")
+        Log.d("LoginDataSourceImpl", "Token: ${response.accessToken}")
         return loginApi.postLoginInfo(loginDto)
     }
 }

--- a/data/src/main/java/com/capston/data/repository/remote/repositoryImpl/LoginRepositoryImpl.kt
+++ b/data/src/main/java/com/capston/data/repository/remote/repositoryImpl/LoginRepositoryImpl.kt
@@ -4,10 +4,12 @@ import com.capston.domain.datasource.LoginDataSource
 import com.capston.domain.repository.LoginRepository
 import com.capston.domain.request.LoginDto
 import com.capston.domain.response.BaseResult
+import com.capston.domain.response.LoginResponse
 import javax.inject.Inject
 
 class LoginRepositoryImpl @Inject constructor(
     private val loginDataSource: LoginDataSource
 ): LoginRepository {
-    override suspend fun postLoginInfo(loginDto: LoginDto): BaseResult = loginDataSource.postLoginInfo(loginDto)
+    override suspend fun postLoginInfo(loginDto: LoginDto): LoginResponse =
+        loginDataSource.postLoginInfo(loginDto)
 }

--- a/data/src/main/java/com/capston/data/repository/remote/repositoryImpl/TokenRepositoryImpl.kt
+++ b/data/src/main/java/com/capston/data/repository/remote/repositoryImpl/TokenRepositoryImpl.kt
@@ -1,0 +1,21 @@
+package com.capston.data.repository
+
+import com.capston.data.local.storage.TokenDataStore
+import com.capston.domain.repository.TokenRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class TokenRepositoryImpl @Inject constructor(
+    private val tokenDataStore: TokenDataStore
+) : TokenRepository {
+
+    override suspend fun saveAccessToken(token: String) {
+        tokenDataStore.saveAccessToken(token)
+    }
+
+    override fun getAccessToken(): Flow<String?> = tokenDataStore.accessToken
+
+    override suspend fun clearTokens() {
+        tokenDataStore.clearTokens()
+    }
+}

--- a/domain/src/main/java/com/capston/domain/datasource/LoginDataSource.kt
+++ b/domain/src/main/java/com/capston/domain/datasource/LoginDataSource.kt
@@ -2,8 +2,9 @@ package com.capston.domain.datasource
 
 import com.capston.domain.request.LoginDto
 import com.capston.domain.response.BaseResult
+import com.capston.domain.response.LoginResponse
 
 interface LoginDataSource {
     // 회원가입 후 사용자 정보 전송
-    suspend fun postLoginInfo(loginDto: LoginDto): BaseResult
+    suspend fun postLoginInfo(loginDto: LoginDto): LoginResponse
 }

--- a/domain/src/main/java/com/capston/domain/repository/LoginRepository.kt
+++ b/domain/src/main/java/com/capston/domain/repository/LoginRepository.kt
@@ -2,8 +2,9 @@ package com.capston.domain.repository
 
 import com.capston.domain.request.LoginDto
 import com.capston.domain.response.BaseResult
+import com.capston.domain.response.LoginResponse
 
 interface LoginRepository {
     // 회원가입 후 사용자 정보 전송
-    suspend fun postLoginInfo(loginDto: LoginDto): BaseResult
+    suspend fun postLoginInfo(loginDto: LoginDto): LoginResponse
 }

--- a/domain/src/main/java/com/capston/domain/repository/TokenRepository.kt
+++ b/domain/src/main/java/com/capston/domain/repository/TokenRepository.kt
@@ -1,0 +1,10 @@
+// domain/src/main/java/com/capston/domain/repository/TokenRepository.kt
+package com.capston.domain.repository
+
+import kotlinx.coroutines.flow.Flow
+
+interface TokenRepository {
+    suspend fun saveAccessToken(token: String)
+    fun getAccessToken(): Flow<String?>
+    suspend fun clearTokens()
+}

--- a/domain/src/main/java/com/capston/domain/response/LoginResponse.kt
+++ b/domain/src/main/java/com/capston/domain/response/LoginResponse.kt
@@ -1,5 +1,5 @@
 package com.capston.domain.response
 
 data class LoginResponse(
-    val token: String = "",
+    val accessToken: String = "",
 )

--- a/domain/src/main/java/com/capston/domain/response/LoginResponse.kt
+++ b/domain/src/main/java/com/capston/domain/response/LoginResponse.kt
@@ -1,5 +1,5 @@
 package com.capston.domain.response
 
 data class LoginResponse(
-    val accessToken: String = "",
+    val token: String = "",
 )

--- a/domain/src/main/java/com/capston/domain/response/LoginResponse.kt
+++ b/domain/src/main/java/com/capston/domain/response/LoginResponse.kt
@@ -1,0 +1,5 @@
+package com.capston.domain.response
+
+data class LoginResponse(
+    val token: String = "",
+)

--- a/domain/src/main/java/com/capston/domain/usecase/login/PostLoginInfoUseCase.kt
+++ b/domain/src/main/java/com/capston/domain/usecase/login/PostLoginInfoUseCase.kt
@@ -3,6 +3,7 @@ package com.capston.domain.usecase.login
 import com.capston.domain.repository.LoginRepository
 import com.capston.domain.request.LoginDto
 import com.capston.domain.response.BaseResult
+import com.capston.domain.response.LoginResponse
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
@@ -10,10 +11,8 @@ import javax.inject.Inject
 class PostLoginInfoUseCase @Inject constructor(
     private val repository: LoginRepository
 ) {
-    operator fun invoke(loginDto: LoginDto): Flow<BaseResult> = flow {
+    operator fun invoke(loginDto: LoginDto): Flow<LoginResponse> = flow {
         val response = repository.postLoginInfo(loginDto)
         emit(response)  // JSON 변환 없이 문자열 그대로 emit
     }
 }
-
-//이거하고 뷰모델만들기

--- a/domain/src/main/java/com/capston/domain/usecase/token/ClearTokensUseCase.kt
+++ b/domain/src/main/java/com/capston/domain/usecase/token/ClearTokensUseCase.kt
@@ -1,0 +1,12 @@
+package com.capston.domain.usecase.token
+
+import com.capston.domain.repository.TokenRepository
+import javax.inject.Inject
+
+class ClearTokensUseCase @Inject constructor(
+    private val tokenRepository: TokenRepository
+) {
+    suspend operator fun invoke() {
+        tokenRepository.clearTokens()
+    }
+}

--- a/domain/src/main/java/com/capston/domain/usecase/token/GetAccessTokenUseCase.kt
+++ b/domain/src/main/java/com/capston/domain/usecase/token/GetAccessTokenUseCase.kt
@@ -1,0 +1,11 @@
+package com.capston.domain.usecase.token
+
+import com.capston.domain.repository.TokenRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetAccessTokenUseCase @Inject constructor(
+    private val tokenRepository: TokenRepository
+) {
+    operator fun invoke(): Flow<String?> = tokenRepository.getAccessToken()
+}

--- a/domain/src/main/java/com/capston/domain/usecase/token/SaveAccessTokenUseCase.kt
+++ b/domain/src/main/java/com/capston/domain/usecase/token/SaveAccessTokenUseCase.kt
@@ -1,0 +1,12 @@
+package com.capston.domain.usecase.token
+
+import com.capston.domain.repository.TokenRepository
+import javax.inject.Inject
+
+class SaveAccessTokenUseCase @Inject constructor(
+    private val tokenRepository: TokenRepository
+) {
+    suspend operator fun invoke(accessToken: String) {
+        tokenRepository.saveAccessToken(accessToken)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -52,8 +52,6 @@ playServicesAuth = "21.3.0"
 googleApiClient = "1.32.1"
 googleHttpClient = "1.32.1"
 rxjava = "2.2.21"
-securityCrypto = "1.1.0-alpha06"
-securityCryptoKtx = "1.0.0-alpha06"
 datastoreCoreAndroid = "1.1.4"
 
 [libraries]
@@ -114,8 +112,6 @@ androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-credentials = { group = "androidx.credentials", name = "credentials", version.ref = "credentials" }
 androidx-credentials-play-services-auth = { group = "androidx.credentials", name = "credentials-play-services-auth", version.ref = "credentials"}
-androidx-security-crypto = { group = "androidx.security", name = "security-crypto", version.ref = "securityCrypto" }
-androidx-security-crypto-ktx = { group = "androidx.security", name = "security-crypto-ktx", version.ref = "securityCryptoKtx" }
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBom" }
 firebase-analytics = { module = "com.google.firebase:firebase-analytics" }
 identity-googleid = { module = "com.google.android.libraries.identity.googleid:googleid", version.ref = "identityGoogleid" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -52,6 +52,7 @@ playServicesAuth = "21.3.0"
 googleApiClient = "1.32.1"
 googleHttpClient = "1.32.1"
 rxjava = "2.2.21"
+securityCrypto = "1.1.0"
 
 [libraries]
 androidx-compose-material3 = { module = "androidx.compose.material3:material3", version.ref = "material3" }
@@ -111,6 +112,7 @@ androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-credentials = { group = "androidx.credentials", name = "credentials", version.ref = "credentials" }
 androidx-credentials-play-services-auth = { group = "androidx.credentials", name = "credentials-play-services-auth", version.ref = "credentials"}
+androidx-security-crypto = { group = "androidx.security", name = "security-crypto", version.ref = "securityCrypto" }
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBom" }
 firebase-analytics = { module = "com.google.firebase:firebase-analytics" }
 identity-googleid = { module = "com.google.android.libraries.identity.googleid:googleid", version.ref = "identityGoogleid" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -52,7 +52,9 @@ playServicesAuth = "21.3.0"
 googleApiClient = "1.32.1"
 googleHttpClient = "1.32.1"
 rxjava = "2.2.21"
-securityCrypto = "1.1.0"
+securityCrypto = "1.1.0-alpha06"
+securityCryptoKtx = "1.0.0-alpha06"
+datastoreCoreAndroid = "1.1.4"
 
 [libraries]
 androidx-compose-material3 = { module = "androidx.compose.material3:material3", version.ref = "material3" }
@@ -113,6 +115,7 @@ androidx-material3 = { group = "androidx.compose.material3", name = "material3" 
 androidx-credentials = { group = "androidx.credentials", name = "credentials", version.ref = "credentials" }
 androidx-credentials-play-services-auth = { group = "androidx.credentials", name = "credentials-play-services-auth", version.ref = "credentials"}
 androidx-security-crypto = { group = "androidx.security", name = "security-crypto", version.ref = "securityCrypto" }
+androidx-security-crypto-ktx = { group = "androidx.security", name = "security-crypto-ktx", version.ref = "securityCryptoKtx" }
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBom" }
 firebase-analytics = { module = "com.google.firebase:firebase-analytics" }
 identity-googleid = { module = "com.google.android.libraries.identity.googleid:googleid", version.ref = "identityGoogleid" }
@@ -126,6 +129,7 @@ android-tools-common = { group = "com.android.tools", name = "common", version.r
 kotlin-gradlePlugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
 ksp-gradlePlugin = { group = "com.google.devtools.ksp", name = "com.google.devtools.ksp.gradle.plugin", version.ref = "ksp" }
 room-gradlePlugin = { group = "androidx.room", name = "room-gradle-plugin", version.ref = "roomRuntime" }
+androidx-datastore-core-android = { group = "androidx.datastore", name = "datastore-core-android", version.ref = "datastoreCoreAndroid" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/presentation/src/main/java/com/capston/presentation/ui/login/LoginActivity.kt
+++ b/presentation/src/main/java/com/capston/presentation/ui/login/LoginActivity.kt
@@ -26,11 +26,13 @@ import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.GoogleAuthProvider
 import com.google.firebase.auth.ktx.auth
 import com.google.firebase.ktx.Firebase
+import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlin.math.sign
 
+@AndroidEntryPoint
 class LoginActivity : ComponentActivity() {
     private lateinit var auth: FirebaseAuth
 

--- a/presentation/src/main/java/com/capston/presentation/ui/login/LoginActivity.kt
+++ b/presentation/src/main/java/com/capston/presentation/ui/login/LoginActivity.kt
@@ -29,6 +29,7 @@ import com.google.firebase.ktx.Firebase
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlin.math.sign
 
 class LoginActivity : ComponentActivity() {
     private lateinit var auth: FirebaseAuth
@@ -43,6 +44,8 @@ class LoginActivity : ComponentActivity() {
         auth = Firebase.auth
         val currentUser = auth.currentUser
         Log.d("LoginActivity", "currentUser: ${currentUser?.uid}")
+
+//        signOut(CredentialManager.create(this))
 
         // 이미 로그인되어 있는지 확인
         if (currentUser != null) {

--- a/presentation/src/main/java/com/capston/presentation/viewmodel/LoginViewModel.kt
+++ b/presentation/src/main/java/com/capston/presentation/viewmodel/LoginViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.capston.domain.request.LoginDto
 import com.capston.domain.response.BaseResult
+import com.capston.domain.response.LoginResponse
 import com.capston.domain.usecase.login.PostLoginInfoUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -18,8 +19,10 @@ import javax.inject.Inject
 class LoginViewModel @Inject constructor(
     private val postLoginInfoUseCase: PostLoginInfoUseCase
 ): ViewModel() {
+    private val _loginResponse = MutableStateFlow(LoginResponse())
+    val loginResponse: StateFlow<LoginResponse> = _loginResponse.asStateFlow()
+
     // 로그인 성공 여부를 나타내는 상태 변수(예: 이벤트 또는 플래그)
-    private val _basicResult = MutableStateFlow(BaseResult)
     private val _loginSuccess = MutableStateFlow(false)
     val loginSuccess: StateFlow<Boolean> = _loginSuccess.asStateFlow()
 
@@ -30,11 +33,23 @@ class LoginViewModel @Inject constructor(
                     Log.e("LoginViewModel", "postLogin error: ${e.message}")
                     // 실패 처리를 위한 추가 로직 추가 가능
                 }
-                .collect {
-                    // 응답 데이터가 없다면 단순히 성공 여부를 업데이트
+                .collect { response ->
+                    _loginResponse.value = response
                     _loginSuccess.value = true
-                    Log.d("LoginViewModel", "로그인 성공")
+                    Log.d("LoginViewModel", "로그인 성공! Token: ${response.token}")
+
+                    // 토큰 저장 로직을 여기에 추가할 수 있습니다
+                    // saveTokens(response.accessToken, response.refreshToken)
                 }
+        }
+    }
+
+    // 토큰 저장 메서드를 추가할 수 있습니다
+    private fun saveTokens(token: String) {
+        viewModelScope.launch {
+            dataStore.edit { preferences ->
+                preferences[ACCESS_TOKEN_KEY] = token
+            }
         }
     }
 }

--- a/presentation/src/main/java/com/capston/presentation/viewmodel/LoginViewModel.kt
+++ b/presentation/src/main/java/com/capston/presentation/viewmodel/LoginViewModel.kt
@@ -46,10 +46,10 @@ class LoginViewModel @Inject constructor(
 
     // 토큰 저장 메서드를 추가할 수 있습니다
     private fun saveTokens(token: String) {
-        viewModelScope.launch {
-            dataStore.edit { preferences ->
-                preferences[ACCESS_TOKEN_KEY] = token
-            }
-        }
+//        viewModelScope.launch {
+//            dataStore.edit { preferences ->
+//                preferences[ACCESS_TOKEN_KEY] = token
+//            }
+//        }
     }
 }

--- a/presentation/src/main/java/com/capston/presentation/viewmodel/LoginViewModel.kt
+++ b/presentation/src/main/java/com/capston/presentation/viewmodel/LoginViewModel.kt
@@ -1,10 +1,10 @@
 package com.capston.presentation.viewmodel
 
+import android.content.Context
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.capston.domain.request.LoginDto
-import com.capston.domain.response.BaseResult
 import com.capston.domain.response.LoginResponse
 import com.capston.domain.usecase.login.PostLoginInfoUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -37,19 +37,7 @@ class LoginViewModel @Inject constructor(
                     _loginResponse.value = response
                     _loginSuccess.value = true
                     Log.d("LoginViewModel", "로그인 성공! Token: ${response.token}")
-
-                    // 토큰 저장 로직을 여기에 추가할 수 있습니다
-                    // saveTokens(response.accessToken, response.refreshToken)
                 }
         }
-    }
-
-    // 토큰 저장 메서드를 추가할 수 있습니다
-    private fun saveTokens(token: String) {
-//        viewModelScope.launch {
-//            dataStore.edit { preferences ->
-//                preferences[ACCESS_TOKEN_KEY] = token
-//            }
-//        }
     }
 }

--- a/presentation/src/main/java/com/capston/presentation/viewmodel/LoginViewModel.kt
+++ b/presentation/src/main/java/com/capston/presentation/viewmodel/LoginViewModel.kt
@@ -1,12 +1,14 @@
 package com.capston.presentation.viewmodel
 
-import android.content.Context
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.capston.domain.request.LoginDto
 import com.capston.domain.response.LoginResponse
 import com.capston.domain.usecase.login.PostLoginInfoUseCase
+import com.capston.domain.usecase.token.ClearTokensUseCase
+import com.capston.domain.usecase.token.GetAccessTokenUseCase
+import com.capston.domain.usecase.token.SaveAccessTokenUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -17,8 +19,12 @@ import javax.inject.Inject
 
 @HiltViewModel
 class LoginViewModel @Inject constructor(
-    private val postLoginInfoUseCase: PostLoginInfoUseCase
+    private val postLoginInfoUseCase: PostLoginInfoUseCase,
+    private val saveTokensUseCase: SaveAccessTokenUseCase,
+    private val getAccessTokenUseCase: GetAccessTokenUseCase,
+    private val clearTokensUseCase: ClearTokensUseCase
 ): ViewModel() {
+    // 회원가입 성공 시 받아오는 액세스 토큰
     private val _loginResponse = MutableStateFlow(LoginResponse())
     val loginResponse: StateFlow<LoginResponse> = _loginResponse.asStateFlow()
 
@@ -36,8 +42,33 @@ class LoginViewModel @Inject constructor(
                 .collect { response ->
                     _loginResponse.value = response
                     _loginSuccess.value = true
-                    Log.d("LoginViewModel", "로그인 성공! Token: ${response.token}")
+                    Log.d("LoginViewModel", "로그인 성공! Access Token: ${response.accessToken}")
+
+                    // 토큰 저장 (비동기 작업)
+                    saveTokensUseCase(
+                        response.accessToken,
+                    )
+                    Log.d("LoginViewModel", "토큰 저장 요청 완료")
+
+                    checkAccessToken()
                 }
+        }
+    }
+
+    // 토큰 정보 수집 예시
+    fun checkAccessToken() {
+        viewModelScope.launch {
+            getAccessTokenUseCase().collect { token ->
+                Log.d("LoginViewModel", "현재 저장된 액세스 토큰: $token")
+            }
+        }
+    }
+
+    // 로그아웃 기능
+    fun logout() {
+        viewModelScope.launch {
+            clearTokensUseCase()
+            Log.d("LoginViewModel", "토큰 삭제 완료")
         }
     }
 }

--- a/presentation/src/main/java/com/capston/presentation/viewmodel/LoginViewModel.kt
+++ b/presentation/src/main/java/com/capston/presentation/viewmodel/LoginViewModel.kt
@@ -42,11 +42,11 @@ class LoginViewModel @Inject constructor(
                 .collect { response ->
                     _loginResponse.value = response
                     _loginSuccess.value = true
-                    Log.d("LoginViewModel", "로그인 성공! Access Token: ${response.accessToken}")
+                    Log.d("LoginViewModel", "로그인 성공! Access Token: ${response.token}")
 
                     // 토큰 저장 (비동기 작업)
                     saveTokensUseCase(
-                        response.accessToken,
+                        response.token,
                     )
                     Log.d("LoginViewModel", "토큰 저장 요청 완료")
 


### PR DESCRIPTION
## #️⃣연관된 이슈

메인 이슈: #38, 참고 이슈: #27, #7

## 📝작업 내용

1. 백엔드에서 액세스 토큰 받아오기
2. 토큰을 DataStore Preference에 저장하기
