### PR TITLE
#107 feat: 계획 생성 후 화면 새로고침

### DIFF
--- a/presentation/src/main/java/com/capston/presentation/ui/MainActivity.kt
+++ b/presentation/src/main/java/com/capston/presentation/ui/MainActivity.kt
@@ -67,6 +67,7 @@ import com.capston.presentation.ui.home.ProfileScreen
 import com.capston.presentation.ui.search.SearchActivity
 import com.capston.presentation.viewmodel.DailyScheduleViewModel
 import com.capston.presentation.viewmodel.HomeViewModel
+import com.capston.presentation.viewmodel.LectureRoomViewModel
 import com.capston.presentation.viewmodel.LoginViewModel
 import com.capston.presentation.viewmodel.MyPageViewModel
 import com.capston.presentation.viewmodel.PlanViewModel
@@ -76,9 +77,12 @@ import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+    val loginViewModel: LoginViewModel by viewModels()
     val homeViewModel: HomeViewModel by viewModels()
     val planViewModel: PlanViewModel by viewModels()
     val dailyScheduleViewModel: DailyScheduleViewModel by viewModels()
+    val lectureRoomViewModel: LectureRoomViewModel by viewModels()
+    val myPageViewModel: MyPageViewModel by viewModels()
 
     @Inject
     lateinit var loadingStateManager: LoadingStateManager
@@ -106,12 +110,6 @@ class MainActivity : ComponentActivity() {
 
         // UI 설정
         setContent {
-            val homeViewModel: HomeViewModel by viewModels()
-            val planViewModel: PlanViewModel by viewModels()
-            val dailyScheduleViewModel: DailyScheduleViewModel by viewModels()
-            val loginViewModel: LoginViewModel by viewModels()
-            val myPageViewModel: MyPageViewModel by viewModels()
-
             LaunchedEffect(Unit) {
                 homeViewModel.getDistinctHome()
                 homeViewModel.getDistinctHome.collectLatest { homeData ->
@@ -129,7 +127,13 @@ class MainActivity : ComponentActivity() {
 
             CapstonTheme {
                 Box(modifier = Modifier.fillMaxSize()) {
-                    SettingTopBottomBar(homeViewModel, planViewModel, dailyScheduleViewModel, loginViewModel, myPageViewModel)
+                    SettingTopBottomBar(
+                        homeViewModel = homeViewModel,
+                        planViewModel = planViewModel,
+                        dailyScheduleViewModel = dailyScheduleViewModel,
+                        lectureRoomViewModel = lectureRoomViewModel,
+                        loginViewModel = loginViewModel,
+                        myPageViewModel = myPageViewModel)
 
                     // 전역 로딩 인디케이터
                     LoadingIndicator(loadingStateManager)
@@ -230,7 +234,14 @@ fun SearchFieldWithIcons(
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
-fun SettingTopBottomBar(homeViewModel: HomeViewModel, planViewModel: PlanViewModel, dailyScheduleViewModel: DailyScheduleViewModel, loginViewModel: LoginViewModel, myPageViewModel: MyPageViewModel) {
+fun SettingTopBottomBar(
+    homeViewModel: HomeViewModel,
+    planViewModel: PlanViewModel,
+    dailyScheduleViewModel: DailyScheduleViewModel,
+    lectureRoomViewModel: LectureRoomViewModel,
+    loginViewModel: LoginViewModel,
+    myPageViewModel: MyPageViewModel
+) {
     var bottomNavState by rememberSaveable { mutableIntStateOf(0) }
     val navController = rememberNavController()
 
@@ -259,7 +270,7 @@ fun SettingTopBottomBar(homeViewModel: HomeViewModel, planViewModel: PlanViewMod
                 composable(Screen.Calender.title) { CalenderScreen(homeViewModel, dailyScheduleViewModel) }
                 composable(Screen.LectureRoom.title) {
                     LectureRoomScreen(
-                        viewModel = planViewModel,
+                        lectureRoomViewModel = lectureRoomViewModel,
                         onPlanClick = { plan ->
                             navController.navigate("${Screen.PlanDetail.title}/${plan.planId}")
                         }
@@ -273,8 +284,7 @@ fun SettingTopBottomBar(homeViewModel: HomeViewModel, planViewModel: PlanViewMod
                     val planDetailResponse = GetPlanDetailResponse()
                     PlanDetailScreen(
                         planId = planId,
-                        planViewModel = planViewModel,
-                        homeViewModel = homeViewModel
+                        lectureRoomViewModel = lectureRoomViewModel
                     )
                 }
                 composable(Screen.Profile.title) { ProfileScreen(loginViewModel = loginViewModel, myPageViewModel = myPageViewModel) }

--- a/presentation/src/main/java/com/capston/presentation/ui/MainActivity.kt
+++ b/presentation/src/main/java/com/capston/presentation/ui/MainActivity.kt
@@ -8,6 +8,7 @@ import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import androidx.activity.ComponentActivity
+import androidx.activity.compose.LocalActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
@@ -73,6 +74,8 @@ import com.capston.presentation.viewmodel.MyPageViewModel
 import com.capston.presentation.viewmodel.PlanViewModel
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -87,7 +90,6 @@ class MainActivity : ComponentActivity() {
     @Inject
     lateinit var loadingStateManager: LoadingStateManager
 
-    // Declare the launcher at the top of your Activity/Fragment:
     // 알림 권한 승인을 위한 런처
     private val requestPermissionLauncher = registerForActivityResult(
         ActivityResultContracts.RequestPermission(),
@@ -96,6 +98,18 @@ class MainActivity : ComponentActivity() {
             // FCM SDK (and your app) can post notifications.
         } else {
             // TODO: Inform user that that your app will not show notifications.
+        }
+    }
+
+    // Register for activity results using the new Activity Result API
+    // 검색 액티비티 실행 및 종료 시 OK를 받기 위한 런처
+    @RequiresApi(Build.VERSION_CODES.O)
+    private val startSearchForResult = registerForActivityResult(
+        ActivityResultContracts.StartActivityForResult()
+    ) { result ->
+        if (result.resultCode == RESULT_OK) {
+            // Refresh all views when returning with RESULT_OK
+            refreshAllData()
         }
     }
 
@@ -159,6 +173,18 @@ class MainActivity : ComponentActivity() {
                 requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
             }
         }
+    }
+
+    fun startSearchActivity() {
+        val intent = Intent(this, SearchActivity::class.java)
+        startSearchForResult.launch(intent)
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    private fun refreshAllData() {
+        homeViewModel.getDistinctHome()
+        dailyScheduleViewModel.getDailySchedule(LocalDate.now().format(DateTimeFormatter.ISO_DATE))
+        lectureRoomViewModel.getPlanLectureRoom()
     }
 }
 
@@ -244,13 +270,19 @@ fun SettingTopBottomBar(
 ) {
     var bottomNavState by rememberSaveable { mutableIntStateOf(0) }
     val navController = rememberNavController()
+    val mainActivity = LocalActivity.current as MainActivity
 
     Scaffold(
         topBar = {
             TopBar(true)
         },
         bottomBar = {
-            BottomBar(navController, bottomNavState, { index -> bottomNavState = index})
+            BottomBar(
+                navController = navController,
+                bottomNavState = bottomNavState,
+                onNavItemClick = { index -> bottomNavState = index},
+                onSearchClick = { mainActivity.startSearchActivity() }
+            )
         },
         // 하단 시스템 바를 고려하도록 contentWindowInsets 설정
         contentWindowInsets = WindowInsets(0, 0, 0, 0)
@@ -358,7 +390,8 @@ fun TopBar(hasUnreadNotifications: Boolean) {
 fun BottomBar(
     navController: NavController,
     bottomNavState: Int,
-    onNavItemClick: (Int) -> Unit
+    onNavItemClick: (Int) -> Unit,
+    onSearchClick: () -> Unit
 ) {
     val items: List<Screen> = listOf(
         Screen.Home,
@@ -411,8 +444,10 @@ fun BottomBar(
 
         FloatingActionButton(
             onClick = {
-                val intent = Intent(context, SearchActivity::class.java)
-                context.startActivity(intent)
+//                val intent = Intent(context, SearchActivity::class.java)
+//                context.startActivity(intent)
+
+                onSearchClick()
             },
             containerColor = MainPurple,
             modifier = Modifier

--- a/presentation/src/main/java/com/capston/presentation/ui/home/LectureRoomScreen.kt
+++ b/presentation/src/main/java/com/capston/presentation/ui/home/LectureRoomScreen.kt
@@ -26,15 +26,16 @@ import androidx.compose.ui.unit.dp
 import com.capston.domain.model.MyLecture
 import com.capston.presentation.theme.MainPurple
 import com.capston.presentation.theme.Typography
+import com.capston.presentation.viewmodel.LectureRoomViewModel
 import com.capston.presentation.viewmodel.PlanViewModel
 
 @Composable
 fun LectureRoomScreen(
-    viewModel: PlanViewModel,
+    lectureRoomViewModel: LectureRoomViewModel,
     onPlanClick: ((MyLecture) -> Unit)?
 ) {
-    val lectures = viewModel.getPlanLectureRoom
-    viewModel.getPlanLectureRoom()
+    val lectures = lectureRoomViewModel.getPlanLectureRoom
+    lectureRoomViewModel.getPlanLectureRoom()
 
     Column(
         modifier = Modifier

--- a/presentation/src/main/java/com/capston/presentation/ui/home/LectureRoomScreen.kt
+++ b/presentation/src/main/java/com/capston/presentation/ui/home/LectureRoomScreen.kt
@@ -17,6 +17,9 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -34,8 +37,12 @@ fun LectureRoomScreen(
     lectureRoomViewModel: LectureRoomViewModel,
     onPlanClick: ((MyLecture) -> Unit)?
 ) {
-    val lectures = lectureRoomViewModel.getPlanLectureRoom
-    lectureRoomViewModel.getPlanLectureRoom()
+    val lectures by lectureRoomViewModel.getPlanLectureRoom.collectAsState()
+
+    // 화면이 처음 표시될 때 데이터를 로드
+    LaunchedEffect(Unit) {
+        lectureRoomViewModel.getPlanLectureRoom()
+    }
 
     Column(
         modifier = Modifier
@@ -49,7 +56,7 @@ fun LectureRoomScreen(
         )
 
         LazyColumn {
-            items(lectures.value) { lecture ->
+            items(lectures) { lecture ->
                 LectureItem(lecture = lecture, onClick = {
                     if (onPlanClick != null) { onPlanClick(lecture) }
                 })

--- a/presentation/src/main/java/com/capston/presentation/ui/home/PlanDetailScreen.kt
+++ b/presentation/src/main/java/com/capston/presentation/ui/home/PlanDetailScreen.kt
@@ -23,6 +23,7 @@ import com.capston.domain.model.LessonSchedule
 import com.capston.domain.response.plan.GetPlanDetailResponse
 import com.capston.presentation.ui.common.CustomCheckBox
 import com.capston.presentation.viewmodel.HomeViewModel
+import com.capston.presentation.viewmodel.LectureRoomViewModel
 import com.capston.presentation.viewmodel.PlanViewModel
 
 import java.time.LocalDate
@@ -39,11 +40,10 @@ fun formatDate(dateString: String): String {
 @Composable
 fun PlanDetailScreen(
     planId: Int,
-    homeViewModel: HomeViewModel,
-    planViewModel: PlanViewModel
+    lectureRoomViewModel: LectureRoomViewModel
 ) {
-    val planDetailResponse by planViewModel.getPlanDetail.collectAsState()
-    planViewModel.getPlanDetail(planId)
+    val planDetailResponse by lectureRoomViewModel.getPlanDetail.collectAsState()
+    lectureRoomViewModel.getPlanDetail(planId)
 
     Column(
         modifier = Modifier
@@ -58,7 +58,7 @@ fun PlanDetailScreen(
             OneDaySection(
                 date = schedule.date,
                 lessonSchedules = schedule.lessonSchedules,
-                homeViewModel = homeViewModel
+                lectureRoomViewModel = lectureRoomViewModel
             )
         }
     }
@@ -93,7 +93,7 @@ fun TitleSection(planDetailResponse: GetPlanDetailResponse) {
 fun OneDaySection(
     date: String,
     lessonSchedules: List<LessonSchedule>,
-    homeViewModel: HomeViewModel
+    lectureRoomViewModel: LectureRoomViewModel
 ) {
     Column(
         modifier = Modifier.padding(vertical = 16.dp, horizontal = 8.dp)
@@ -107,7 +107,7 @@ fun OneDaySection(
         lessonSchedules.forEach { lessonSchedule ->
             TaskItem(
                 lessonSchedule = lessonSchedule,
-                homeViewModel = homeViewModel
+                lectureRoomViewModel = lectureRoomViewModel
             )
         }
     }
@@ -116,7 +116,7 @@ fun OneDaySection(
 @Composable
 fun TaskItem(
     lessonSchedule: LessonSchedule,
-    homeViewModel: HomeViewModel
+    lectureRoomViewModel: LectureRoomViewModel
 ) {
     // 각 체크박스의 상태를 기억합니다.
     var isChecked by remember { mutableStateOf(lessonSchedule.completed) }
@@ -129,7 +129,7 @@ fun TaskItem(
         CustomCheckBox (
             isChecked = isChecked,
             onCheckedChange = {
-                homeViewModel.patchLessonSchedulesCheckToggle(lessonSchedule.id)
+                lectureRoomViewModel.patchLessonSchedulesCheckToggle(lessonSchedule.id)
                 isChecked = !isChecked
             }
         )

--- a/presentation/src/main/java/com/capston/presentation/ui/search/MakePlanScreen.kt
+++ b/presentation/src/main/java/com/capston/presentation/ui/search/MakePlanScreen.kt
@@ -1,6 +1,9 @@
 package com.capston.presentation.ui.search
 
+import android.app.Activity
+import android.os.Build
 import androidx.activity.ComponentActivity
+import androidx.annotation.RequiresApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -36,6 +39,9 @@ import com.capston.presentation.theme.backgroundGray
 import com.capston.presentation.theme.chipGray
 import com.capston.presentation.theme.dividerGray
 import com.capston.presentation.theme.textGray
+import com.capston.presentation.viewmodel.DailyScheduleViewModel
+import com.capston.presentation.viewmodel.HomeViewModel
+import com.capston.presentation.viewmodel.LectureRoomViewModel
 import com.capston.presentation.viewmodel.LectureViewModel
 import com.capston.presentation.viewmodel.PlanViewModel
 import kotlinx.coroutines.CoroutineScope
@@ -43,6 +49,8 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import java.text.ParseException
 import java.text.SimpleDateFormat
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 import java.util.Date
 import java.util.Locale
 
@@ -55,6 +63,7 @@ fun formatDate(millis: Long?): String {
     }
 }
 
+@RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun MakePlanScreen(
     lectureViewModel: LectureViewModel,
@@ -118,7 +127,12 @@ fun MakePlanScreen(
             // 성공적인 응답을 받았음
             delay(1000) // 로딩 표시를 위한 지연
             loadingStateManager.hide()
-            (context as? ComponentActivity)?.finish()
+
+            // Set the result to RESULT_OK
+            if (context is ComponentActivity) {
+                context.setResult(Activity.RESULT_OK)
+                context.finish()
+            }
         }
     }
 

--- a/presentation/src/main/java/com/capston/presentation/viewmodel/LectureRoomViewModel.kt
+++ b/presentation/src/main/java/com/capston/presentation/viewmodel/LectureRoomViewModel.kt
@@ -77,28 +77,23 @@ class LectureRoomViewModel @Inject constructor(
         }
     }
 
-    fun patchLessonSchedulesCheckToggle(
-        lessonScheduleId: Int
-    ) {
+    fun patchLessonSchedulesCheckToggle(lessonScheduleId: Int) {
         viewModelScope.launch {
-
-            val currentTime = System.currentTimeMillis()
-            val isCacheValid = currentTime - lastLoadTime < cacheValidDuration
-
-            if (isCacheValid) {
-                // 캐시된 데이터 사용, 로딩 인디케이터 표시 안 함
-                return@launch
-            }
-
             loadingStateManager.show()
             try {
-                patchLessonSchedulesCheckToggleUseCase(lessonScheduleId).collect {
-                    _patchLessonSchedulesCheckToggle.value = it
-                    // 체크 토글 후 홈 데이터 새로고침
-                    getDistinctHome()
+                patchLessonSchedulesCheckToggleUseCase(lessonScheduleId).collect { response ->
+                    _patchLessonSchedulesCheckToggle.value = response
+                    // 체크 토글 후 강의실 데이터 새로고침 (대신 getPlanLectureRoom 호출)
+                    getPlanLectureRoom()
+
+                    // 현재 보고 있는 계획 세부 정보도 새로고침
+                    val currentPlanId = _getPlanDetail.value.planId
+                    if (currentPlanId > 0) {
+                        getPlanDetail(currentPlanId)
+                    }
                 }
             } catch (e: Exception) {
-                Log.e("patch lesson schedule toggle 에러", e.message.toString())
+                Log.e("LectureRoomViewModel", "체크 토글 오류: ${e.message}", e)
             } finally {
                 loadingStateManager.hide()
             }

--- a/presentation/src/main/java/com/capston/presentation/viewmodel/LectureRoomViewModel.kt
+++ b/presentation/src/main/java/com/capston/presentation/viewmodel/LectureRoomViewModel.kt
@@ -1,0 +1,107 @@
+package com.capston.presentation.viewmodel
+
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.capston.domain.manager.LoadingStateManager
+import com.capston.domain.model.LectureItemDto
+import com.capston.domain.model.MyLecture
+import com.capston.domain.model.NewPlanLesson
+import com.capston.domain.request.LectureDto
+import com.capston.domain.request.PatchPlanDto
+import com.capston.domain.request.PostNewPlanDto
+import com.capston.domain.response.CheckResponse
+import com.capston.domain.response.lecture.DistinctLectureResponse
+import com.capston.domain.response.lecture.LectureResponseDto
+import com.capston.domain.response.plan.GetPlanDetailResponse
+import com.capston.domain.response.plan.LectureAliasResponse
+import com.capston.domain.response.plan.PostNewPlanResponse
+import com.capston.domain.usecase.home.PatchLessonSchedulesCheckToggleUseCase
+import com.capston.domain.usecase.lecture.GetAllLectureUseCase
+import com.capston.domain.usecase.lecture.GetDistinctLectureUseCase
+import com.capston.domain.usecase.lecture.GetLessonsByLectureIdUseCase
+import com.capston.domain.usecase.plan.GetPlanDetailUseCase
+import com.capston.domain.usecase.plan.GetPlanLectureRoomUseCase
+import com.capston.domain.usecase.plan.PatchPlanNameUseCase
+import com.capston.domain.usecase.plan.PostNewPlanUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class LectureRoomViewModel @Inject constructor(
+    private val getPlanLectureRoomUseCase: GetPlanLectureRoomUseCase,
+    private val getPlanDetailUseCase: GetPlanDetailUseCase,
+    private val patchLessonSchedulesCheckToggleUseCase: PatchLessonSchedulesCheckToggleUseCase,
+    private val loadingStateManager: LoadingStateManager
+) : ViewModel() {
+
+    private val _getPlanLectureRoom = MutableStateFlow(emptyList<MyLecture>())  // 기본값 ""
+    val getPlanLectureRoom: StateFlow<List<MyLecture>> = _getPlanLectureRoom.asStateFlow()
+
+    private val _getPlanDetail = MutableStateFlow(GetPlanDetailResponse())  // 기본값 ""
+    val getPlanDetail: StateFlow<GetPlanDetailResponse> = _getPlanDetail.asStateFlow()
+
+    private val _patchLessonSchedulesCheckToggle = MutableStateFlow(CheckResponse())
+    val patchLessonSchedulesCheckToggle = _patchLessonSchedulesCheckToggle
+
+    fun getPlanLectureRoom() {
+        viewModelScope.launch {
+            loadingStateManager.show()
+            getPlanLectureRoomUseCase()
+                .catch { e ->
+                    Log.e("PlanViewModel", "getPlanLectureRoom 에러: ${e.message}")
+                }
+                .collect { response ->  // 값 저장
+                    _getPlanLectureRoom.value = response // 공백 제거 후 저장
+                    Log.d("PlanViewModel", "getPlanLectureRoom 업데이트됨: $response")
+                }
+            loadingStateManager.hide()
+        }
+    }
+
+    fun getPlanDetail(planId: Int) {
+        viewModelScope.launch {
+            getPlanDetailUseCase(planId)
+                .catch { e ->
+                    Log.e("PlanViewModel", "getPlanDetail 에러: ${e.message}")
+                }
+                .collect { response ->  // 값 저장
+                    _getPlanDetail.value = response // 공백 제거 후 저장
+                    Log.d("PlanViewModel", "getPlanDetail 업데이트됨: $response")
+                }
+        }
+    }
+
+    fun patchLessonSchedulesCheckToggle(
+        lessonScheduleId: Int
+    ) {
+        viewModelScope.launch {
+
+            val currentTime = System.currentTimeMillis()
+            val isCacheValid = currentTime - lastLoadTime < cacheValidDuration
+
+            if (isCacheValid) {
+                // 캐시된 데이터 사용, 로딩 인디케이터 표시 안 함
+                return@launch
+            }
+
+            loadingStateManager.show()
+            try {
+                patchLessonSchedulesCheckToggleUseCase(lessonScheduleId).collect {
+                    _patchLessonSchedulesCheckToggle.value = it
+                    // 체크 토글 후 홈 데이터 새로고침
+                    getDistinctHome()
+                }
+            } catch (e: Exception) {
+                Log.e("patch lesson schedule toggle 에러", e.message.toString())
+            } finally {
+                loadingStateManager.hide()
+            }
+        }
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

메인 이슈: #107, 참고 이슈: 없음

## 📝작업 내용

- 메인에서 검색 액티비티로 넘어가는 로직 변경
- 다시 메인으로 돌아올 때 RESULT_OK를 받아 뷰모델 함수들 다시 호출
- planViewModel과 lectureViewModel에 산재해 있던 나의 강의실 관련 로직을 LectureRoomViewModel로 합쳐서 이동
