### PR TITLE
#117 fix 홈화면 에러 해결

### DIFF
--- a/domain/src/main/java/com/capston/domain/response/mypage/GetDistinctMyPageResponse.kt
+++ b/domain/src/main/java/com/capston/domain/response/mypage/GetDistinctMyPageResponse.kt
@@ -6,7 +6,7 @@ data class GetDistinctMyPageResponse(
     val todayCompletedLessonCount: Int = 0,
     val completedLectureCount: Int = 0,
     val studyStreak: Int = 0,
-    val goalDate: Int = 0,
+    val inProgressLectureCount: Int = 0,
     val completedPlanList: List<CompletedPlanDto> = emptyList(),
     val subjectAchievementList: List<SubjectAchievementDto> = emptyList()
 )

--- a/presentation/src/main/java/com/capston/presentation/ui/MainActivity.kt
+++ b/presentation/src/main/java/com/capston/presentation/ui/MainActivity.kt
@@ -386,67 +386,6 @@ fun SettingTopBottomBar(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-fun TopBar(hasUnreadNotifications: Boolean) {
-    Column {
-        TopAppBar(
-            title = {},
-            modifier = Modifier
-                .padding(10.dp)
-                .clip(RoundedCornerShape(20.dp))
-                .height(80.dp),
-            navigationIcon = {
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    // 앱 로고
-                    Icon(
-                        painter = painterResource(id = R.drawable.ic_launcher),
-                        contentDescription = "앱 로고",
-                        modifier = Modifier.size(50.dp),
-                        tint = Color.Unspecified
-                    )
-
-                    // 간격 추가
-                    Spacer(modifier = Modifier.width(5.dp))
-
-                    // 앱 이름
-                    Icon(
-                        painter = painterResource(id = R.drawable.landr_title_iv),
-                        contentDescription = "앱 이름",
-                        modifier = Modifier.size(70.dp),
-                        tint = Color.Unspecified
-                    )
-                }
-            },
-            actions = {
-                Box(contentAlignment = Alignment.TopEnd) {
-                    IconButton(onClick = { /* 알람 클릭 */ }) {
-                        Icon(
-                            painter = painterResource(R.drawable.home_screen_notification_iv),
-                            contentDescription = "alarm icon",
-                        )
-                    }
-
-                    // 읽지 않은 알람이 있을 경우 빨간색 배지 표시
-                    if (hasUnreadNotifications) {
-                        Box(
-                            modifier = Modifier
-                                .size(10.dp)
-                                .align(Alignment.TopEnd)
-                                .offset(x = (-12).dp, y = (10).dp) // 위치 조정
-                                .background(Color.Red, shape = CircleShape)
-                                .border(1.dp, Color.White, CircleShape)
-                        )
-                    }
-                }
-            }
-        )
-        Divider(color = LightGray2, thickness = 1.dp)
-    }
-}
-
 @Composable
 fun BottomBar(
     navController: NavController,

--- a/presentation/src/main/java/com/capston/presentation/ui/MainActivity.kt
+++ b/presentation/src/main/java/com/capston/presentation/ui/MainActivity.kt
@@ -73,6 +73,7 @@ import com.capston.presentation.viewmodel.LoginViewModel
 import com.capston.presentation.viewmodel.MyPageViewModel
 import com.capston.presentation.viewmodel.PlanViewModel
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
@@ -119,12 +120,15 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
 
+        loginViewModel.checkAccessToken()
+
         // 알림 권한 묻기
         askNotificationPermission()
 
         // UI 설정
         setContent {
             LaunchedEffect(Unit) {
+                delay(500)
                 homeViewModel.getDistinctHome()
                 homeViewModel.getDistinctHome.collectLatest { homeData ->
                     val dday = homeData.dday

--- a/presentation/src/main/java/com/capston/presentation/ui/MainActivity.kt
+++ b/presentation/src/main/java/com/capston/presentation/ui/MainActivity.kt
@@ -8,6 +8,7 @@ import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import androidx.activity.ComponentActivity
+import androidx.activity.compose.BackHandler
 import androidx.activity.compose.LocalActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -87,6 +88,10 @@ class MainActivity : ComponentActivity() {
     val dailyScheduleViewModel: DailyScheduleViewModel by viewModels()
     val lectureRoomViewModel: LectureRoomViewModel by viewModels()
     val myPageViewModel: MyPageViewModel by viewModels()
+
+    // 뒤로가기 두 번 누르기 위한 변수들
+    var backPressedTime: Long = 0
+    val BACK_PRESS_INTERVAL: Long = 2000 // 2초 내에 두 번 눌러야 함
 
     @Inject
     lateinit var loadingStateManager: LoadingStateManager
@@ -276,6 +281,35 @@ fun SettingTopBottomBar(
     var bottomNavState by rememberSaveable { mutableIntStateOf(0) }
     val navController = rememberNavController()
     val mainActivity = LocalActivity.current as MainActivity
+    val context = LocalContext.current
+
+    // 뒤로가기 처리 추가 - 상태를 기반으로 처리
+    BackHandler {
+        if (bottomNavState == 0) {
+            // 홈 화면에서는 원래 코드대로 앱 종료 로직 실행
+            val currentTime = System.currentTimeMillis()
+            if (currentTime - mainActivity.backPressedTime < mainActivity.BACK_PRESS_INTERVAL) {
+                mainActivity.finish()
+            } else {
+                mainActivity.backPressedTime = currentTime
+                android.widget.Toast.makeText(
+                    context,
+                    "한 번 더 뒤로가기를 누르면 앱이 종료됩니다",
+                    android.widget.Toast.LENGTH_SHORT
+                ).show()
+            }
+        } else {
+            // 어떤 화면에서든 항상 홈으로 강제 이동
+            bottomNavState = 0
+
+            // 백스택을 완전히 비우고 홈으로 이동
+            navController.navigate(Screen.Home.title) {
+                popUpTo(0) {
+                    inclusive = true
+                }
+            }
+        }
+    }
 
     Scaffold(
 //        topBar = {
@@ -285,7 +319,28 @@ fun SettingTopBottomBar(
             BottomBar(
                 navController = navController,
                 bottomNavState = bottomNavState,
-                onNavItemClick = { index -> bottomNavState = index},
+                onNavItemClick = { index ->
+                    // 이전 상태와 현재 선택한 상태가 같지 않을 때만 처리
+                    if (bottomNavState != index) {
+                        bottomNavState = index
+                        val destination = when (index) {
+                            0 -> Screen.Home.title
+                            1 -> Screen.Calender.title
+                            2 -> Screen.LectureRoom.title
+                            3 -> Screen.Profile.title
+                            else -> Screen.Home.title
+                        }
+
+                        // 이동 시 백스택을 완전히 비우고 새 화면으로 교체
+                        navController.navigate(destination) {
+                            // 백스택 완전히 비우기 - 그래프 ID를 사용
+                            popUpTo(0) {
+                                inclusive = true
+                            }
+                            launchSingleTop = true
+                        }
+                    }
+                },
                 onSearchClick = { mainActivity.startSearchActivity() }
             )
         },
@@ -430,7 +485,7 @@ fun BottomBar(
                     selected = bottomNavState == index,
                     onClick = {
                         onNavItemClick(index)
-                        navController.navigate(item.title) // 클릭 시 해당 화면으로 이동
+                        //navController.navigate(item.title) // 클릭 시 해당 화면으로 이동
                     },
                     icon = {
                         when (val icon = if (bottomNavState == index) item.selectedIcon else item.unselectedIcon) {

--- a/presentation/src/main/java/com/capston/presentation/ui/home/MyPageScreen.kt
+++ b/presentation/src/main/java/com/capston/presentation/ui/home/MyPageScreen.kt
@@ -70,6 +70,7 @@ import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.nativeCanvas
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -1254,10 +1255,10 @@ fun LectureItem(lecture: CompletedPlanDto, isLastItem: Boolean) {
 }
 
 // Canvas 컨텍스트 내에서 말풍선 그리기 함수
-private fun DrawScope.drawBubbleWithText(text: String, position: Offset) {
+private fun DrawScope.drawBubbleWithText(text: String, minutes: Int, position: Offset) {
     // 말풍선 배경
-    val bubbleWidth = 50.dp.toPx()
-    val bubbleHeight = 30.dp.toPx()
+    val bubbleWidth = 70.dp.toPx()
+    val bubbleHeight = 40.dp.toPx()
     val cornerRadius = 10.dp.toPx()
 
     drawRoundRect(
@@ -1287,12 +1288,30 @@ private fun DrawScope.drawBubbleWithText(text: String, position: Offset) {
     drawContext.canvas.nativeCanvas.drawText(
         text,
         position.x,
-        position.y + 5.dp.toPx(), // 약간의 수직 중앙 정렬 조정
+        position.y, // 약간의 수직 중앙 정렬 조정
         android.graphics.Paint().apply {
             color = android.graphics.Color.BLACK
             textAlign = android.graphics.Paint.Align.CENTER
             textSize = 14.sp.toPx()
             isFakeBoldText = true
+        }
+    )
+
+    // Draw minutes text below the subject name
+    val minutesText = if (minutes >= 60) {
+        "${minutes / 60}시간 ${minutes % 60}분"
+    } else {
+        "${minutes}분"
+    }
+
+    drawContext.canvas.nativeCanvas.drawText(
+        minutesText,
+        position.x,
+        position.y + 15.dp.toPx(), // 과목 이름 아래에 표시
+        android.graphics.Paint().apply {
+            color = textGray.toArgb()
+            textAlign = android.graphics.Paint.Align.CENTER
+            textSize = 12.sp.toPx()
         }
     )
 }
@@ -1548,7 +1567,7 @@ fun SubjectPieChartWithBubbles(subjects: List<SubjectDataDto>, angles: List<Floa
                 val bubbleY = center.y + bubbleDistance * kotlin.math.sin(midAngleRad).toFloat()
 
                 // 말풍선 배경 그리기
-                drawBubbleWithText(subject.subject.label, Offset(bubbleX, bubbleY))
+                drawBubbleWithText(subject.subject.label, subject.hours, Offset(bubbleX, bubbleY))
             }
 
             // 다음 시작 각도 업데이트

--- a/presentation/src/main/java/com/capston/presentation/ui/home/MyPageScreen.kt
+++ b/presentation/src/main/java/com/capston/presentation/ui/home/MyPageScreen.kt
@@ -1455,7 +1455,7 @@ fun SubjectDistributionGraph(
                         append("에 ")
                         if (maxHours >= 60) {
                             withStyle(style = SpanStyle(color = SubPurple)) {
-                                append((maxHours / 60).toString() + "시간")
+                                append((maxHours / 60).toString() + "시간 " + (maxHours % 60).toString() + "분")
                             }
                         }
                         else {
@@ -2075,7 +2075,7 @@ fun DynamicWeeklyBarChart(
                         // 분 표시
                         Text(
                             text = if (data.totalMinutes>= 60){
-                                "${data.totalMinutes/60}시간"
+                                "${data.totalMinutes/60}시간 ${data.totalMinutes%60}분"
                             } else {
                                 "${data.totalMinutes}분"
                             },

--- a/presentation/src/main/java/com/capston/presentation/ui/home/MyPageScreen.kt
+++ b/presentation/src/main/java/com/capston/presentation/ui/home/MyPageScreen.kt
@@ -1255,7 +1255,7 @@ fun LectureItem(lecture: CompletedPlanDto, isLastItem: Boolean) {
 }
 
 // Canvas 컨텍스트 내에서 말풍선 그리기 함수
-private fun DrawScope.drawBubbleWithText(text: String, minutes: Int, position: Offset) {
+private fun DrawScope.drawBubbleWithText(text: String, minutes: Int, maxHour: Int, topSubject: String, position: Offset) {
     // 말풍선 배경
     val bubbleWidth = 70.dp.toPx()
     val bubbleHeight = 40.dp.toPx()
@@ -1290,7 +1290,7 @@ private fun DrawScope.drawBubbleWithText(text: String, minutes: Int, position: O
         position.x,
         position.y, // 약간의 수직 중앙 정렬 조정
         android.graphics.Paint().apply {
-            color = android.graphics.Color.BLACK
+            color = if (minutes == maxHour) MainPurple.toArgb() else Color.Black.toArgb()
             textAlign = android.graphics.Paint.Align.CENTER
             textSize = 14.sp.toPx()
             isFakeBoldText = true
@@ -1542,6 +1542,10 @@ fun SubjectPieChartWithBubbles(subjects: List<SubjectDataDto>, angles: List<Floa
 
         var startAngle = -90f // 12시 방향에서 시작
 
+        val maxHours = subjects.maxOf { it.hours }
+        val topSubjects = subjects.filter { it.hours == maxHours }
+        val topSubjectsText = topSubjects.joinToString(", ") { it.subject.label }
+
         // 각 과목별 부분 그리기
         subjects.forEachIndexed { index, subject ->
             val sweepAngle = animatedValues[index].value
@@ -1567,7 +1571,7 @@ fun SubjectPieChartWithBubbles(subjects: List<SubjectDataDto>, angles: List<Floa
                 val bubbleY = center.y + bubbleDistance * kotlin.math.sin(midAngleRad).toFloat()
 
                 // 말풍선 배경 그리기
-                drawBubbleWithText(subject.subject.label, subject.hours, Offset(bubbleX, bubbleY))
+                drawBubbleWithText(subject.subject.label, subject.hours, maxHours, topSubjectsText, Offset(bubbleX, bubbleY))
             }
 
             // 다음 시작 각도 업데이트

--- a/presentation/src/main/java/com/capston/presentation/ui/home/MyPageScreen.kt
+++ b/presentation/src/main/java/com/capston/presentation/ui/home/MyPageScreen.kt
@@ -457,40 +457,42 @@ fun ProfileScreen(loginViewModel: LoginViewModel, myPageViewModel: MyPageViewMod
             // 하단 여백
             Spacer(modifier = Modifier.height(20.dp))
 
-            Text(
-                text = "로그아웃",
-                color = MainPurple,
+            Spacer(modifier = Modifier.weight(1f))
+
+// Box를 사용하여 가로 중앙 정렬
+            Box(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .clickable {
-                        scope.launch {
-                            // Perform logout in coroutine
-                            loginViewModel.logout()
+                    .padding(bottom = 32.dp), // 하단 여백 추가
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = "로그아웃",
+                    color = MainPurple,
+                    fontSize = 16.sp, // 폰트 크기 키우기
+                    modifier = Modifier
+                        .clickable {
+                            scope.launch {
+                                // 로그아웃
+                                loginViewModel.logout()
 
-                            try {
-                                // Create a completely new task with LoginActivity
-                                val intent = Intent(context, LoginActivity::class.java).apply {
-                                    flags = Intent.FLAG_ACTIVITY_NEW_TASK or
-                                            Intent.FLAG_ACTIVITY_CLEAR_TASK
+                                try {
+                                    // 로그인 액티비티 이동
+                                    val intent = Intent(context, LoginActivity::class.java).apply {
+                                        flags = Intent.FLAG_ACTIVITY_NEW_TASK or
+                                                Intent.FLAG_ACTIVITY_CLEAR_TASK
+                                    }
+
+                                    Log.d("ProfileScreen", "Starting LoginActivity, context: $context")
+                                    context.startActivity(intent)
+                                } catch (e: Exception) {
+                                    Log.e("ProfileScreen", "Error during logout navigation: ${e.message}", e)
                                 }
-
-                                // Log before navigation
-                                Log.d("ProfileScreen", "Starting LoginActivity, context: $context")
-                                context.startActivity(intent)
-
-//                                // Force stop the current app process (use with caution)
-//                                if (context is Activity) {
-//                                    Log.d("ProfileScreen", "Finishing activity")
-//                                    context.finishAffinity()
-//                                    android.os.Process.killProcess(android.os.Process.myPid())
-//                                }
-                            } catch (e: Exception) {
-                                Log.e("ProfileScreen", "Error during logout navigation: ${e.message}", e)
                             }
                         }
-                    }
-                    .padding(16.dp)
-            )
+                        .padding(16.dp)
+                )
+            }
         }
     }
 }

--- a/presentation/src/main/java/com/capston/presentation/ui/home/MyPageScreen.kt
+++ b/presentation/src/main/java/com/capston/presentation/ui/home/MyPageScreen.kt
@@ -362,7 +362,7 @@ fun ProfileScreen(loginViewModel: LoginViewModel, myPageViewModel: MyPageViewMod
 
                         Spacer(modifier = Modifier.height(4.dp))
                         Text(
-                            text = "${mypageState.subjectAchievementList.size}개",
+                            text = "${mypageState.inProgressLectureCount}개",
                             color = Color.White,
                             style = MaterialTheme.typography.bodyMedium,
                             fontSize = 18.sp

--- a/presentation/src/main/java/com/capston/presentation/ui/login/LoginActivity.kt
+++ b/presentation/src/main/java/com/capston/presentation/ui/login/LoginActivity.kt
@@ -35,6 +35,7 @@ import com.google.firebase.messaging.FirebaseMessaging
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -147,8 +148,11 @@ class LoginActivity : ComponentActivity() {
                                 token
                             )
                         )
-                        startActivity(Intent(this, MainActivity::class.java))
-                        finish()
+                        lifecycleScope.launch {
+                            delay(1000) // Wait for token to be saved and processed
+                            startActivity(Intent(this@LoginActivity, MainActivity::class.java))
+                            finish()
+                        }
                     }
                 } else {
                     // If sign in fails, display a message to the user

--- a/presentation/src/main/java/com/capston/presentation/viewmodel/LoginViewModel.kt
+++ b/presentation/src/main/java/com/capston/presentation/viewmodel/LoginViewModel.kt
@@ -15,6 +15,7 @@ import com.capston.domain.usecase.token.ClearTokensUseCase
 import com.capston.domain.usecase.token.GetAccessTokenUseCase
 import com.capston.domain.usecase.token.SaveAccessTokenUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -46,25 +47,28 @@ class LoginViewModel @Inject constructor(
     fun postLogin(loginDto: LoginDto) {
         viewModelScope.launch {
             loadingStateManager.show()
-            postLoginInfoUseCase(loginDto)
-                .catch { e ->
-                    Log.e("LoginViewModel", "postLogin error: ${e.message}")
-                    // 실패 처리를 위한 추가 로직 추가 가능
-                }
-                .collect { response ->
-                    _loginResponse.value = response
-                    _loginSuccess.value = true
-                    Log.d("LoginViewModel", "로그인 성공! Access Token: ${response.token}")
+            try {
+                postLoginInfoUseCase(loginDto)
+                    .catch { e ->
+                        Log.e("LoginViewModel", "postLogin error: ${e.message}")
+                    }
+                    .collect { response ->
+                        _loginResponse.value = response
+                        _loginSuccess.value = true
+                        Log.d("LoginViewModel", "로그인 성공! Access Token: ${response.token}")
 
-                    // 토큰 저장 (비동기 작업)
-                    saveAccessTokenUseCase(
-                        response.token,
-                    )
-                    Log.d("LoginViewModel", "토큰 저장 요청 완료")
+                        // Ensure token is fully saved before continuing
+                        saveAccessTokenUseCase(response.token)
 
-                    checkAccessToken()
-                }
+                        // Wait a moment to ensure token is properly stored
+                        delay(500)
+
+                        // Check if token is actually stored
+                        checkAccessToken()
+                    }
+            } finally {
                 loadingStateManager.hide()
+            }
         }
     }
 

--- a/presentation/src/main/java/com/capston/presentation/viewmodel/LoginViewModel.kt
+++ b/presentation/src/main/java/com/capston/presentation/viewmodel/LoginViewModel.kt
@@ -14,6 +14,8 @@ import com.capston.domain.usecase.login.PostLoginInfoUseCase
 import com.capston.domain.usecase.token.ClearTokensUseCase
 import com.capston.domain.usecase.token.GetAccessTokenUseCase
 import com.capston.domain.usecase.token.SaveAccessTokenUseCase
+import com.google.firebase.Firebase
+import com.google.firebase.auth.auth
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -86,6 +88,10 @@ class LoginViewModel @Inject constructor(
     fun logout() {
         viewModelScope.launch {
             loadingStateManager.show()
+
+            // Firebase 로그아웃 처리 추가
+            Firebase.auth.signOut()
+
             clearTokensUseCase()
 
             Log.d("LoginViewModel", "Tokens and saved name cleared")


### PR DESCRIPTION
## #️⃣연관된 이슈

메인 이슈: #117, 참고 이슈: 없음

## 📝작업 내용

- 최초 로그인 후 홈화면 이동 시 403에러 해결 (access token 저장 안 되어 있을 때)
- 백스택 정리 (홈화면에서 뒤로가기 시 Toast 메시지, 바텀 바에 있는 화면 이동 후 뒤로가기 눌렀을 때 홈화면으로 오도록)
- 로그아웃 에러 해결
- 마이페이지 시간 + 분도 표시

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
