### PR TITLE
FEAT(HomeScreen.kt) : 계획 생성 시에도 8글자 제한

### DIFF
--- a/presentation/src/main/java/com/capston/presentation/ui/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/capston/presentation/ui/home/HomeScreen.kt
@@ -857,7 +857,12 @@ fun LearningProgressGraphs(
                 val currentLectureName = if (item.planId == patchData.planId) {
                     patchData.lectureAlias
                 } else {
-                    item.lectureAlias
+                    if (item.lectureAlias.length > 8) {
+                        item.lectureAlias.take(8) + "..."
+                    }
+                    else {
+                        item.lectureAlias
+                    }
                 }
                 CircleGraph(
                     name = currentLectureName,


### PR DESCRIPTION
## #️⃣연관된 이슈

메인 이슈: #152, 참고 이슈: #86

## 📝작업 내용

계획 생성 시에도 8글자 제한 걸어 표시